### PR TITLE
Fix postgres installation check

### DIFF
--- a/manual-setup-check.sh
+++ b/manual-setup-check.sh
@@ -110,7 +110,7 @@ delimiter
 
 ## 12. Databases
 print_table_results "Installed sqlite" "command -v sqlite3 >/dev/null 2>&1"
-print_table_results "Installed PostgreSQL" "command -v postgres | grep -q 'postgres (PostgreSQL)'"
+print_table_results "Installed PostgreSQL" "command -v postgres | grep -q 'postgres'"
 print_table_results "Installed psql" "command -v psql >/dev/null 2>&1 && psql --version | grep -q 'psql (PostgreSQL)'"
 delimiter
 


### PR DESCRIPTION
Fix the postgres installation check so it can pass.

The output of `command -v postgres` when `postgres` is installed via Homebrew is not reflected in the 
current regular expression passed to grep, so the test for postgres installation used to always fail. 
Remove the string `(PostgreSQL)` from the regex passed to grep so the test can pass.

##### Problem

Below is the output of `command -v postgres` after `postgres` is installed via homebrew:

```
$ command -v postgres
/usr/local/bin/postgres
```

The output does not contain the string `PostgreSQL` so the test always fails.

##### Solution

Remove the string `(PostgreSQL)` from the regex passed to `grep` on line 113:

```
print_table_results "Installed PostgreSQL" "command -v postgres | grep -q 'postgres (PostgreSQL)'"
```
Becomes: 
```
print_table_results "Installed PostgreSQL" "command -v postgres | grep -q 'postgres'"
```