### PR TITLE
Fix: Update Node version check to include v21 and v22Fix Node version check to support v21 and v22

### DIFF
--- a/wsl-phase-0-manual-setup-validator-with-py.sh
+++ b/wsl-phase-0-manual-setup-validator-with-py.sh
@@ -65,7 +65,7 @@ delimiter
 . ~/.nvm/nvm.sh
 print_table_results "Installed NVM" "command -v nvm >/dev/null 2>&1 && nvm --version | grep -q '[0-9]*\.[0-9]*\.[0-9]*'"
 print_table_results "Installed Node" "command -v node | grep -q '.nvm/versions/node'"
-print_table_results "Default Node (>11.x)" 'command -v nvm >/dev/null 2>&1 && nvm version default | grep -q "v11\|v12\|v13\|v14\|v15\|v16\|v17\|v18\|v19\|v20"'
+print_table_results "Default Node (>11.x)" 'command -v nvm >/dev/null 2>&1 && nvm version default | grep -q "v11\|v12\|v13\|v14\|v15\|v16\|v17\|v18\|v19\|v20\|v21\|v22"'
 # print_table_results "Default Node (10.x)" 'command -v nvm >/dev/null 2>&1 && nvm version default | grep -q "v10"'
 # print_table_results "Default Node (6.11.2)" 'command -v nvm >/dev/null 2>&1 && nvm version default | grep -q "v6.11.2"'
 delimiter


### PR DESCRIPTION
This update ensures the setup validator correctly detects the latest Node.js versions, including v21 and v22, as valid default versions. Previously, the script only checked for versions up to v20, causing false failures for users with newer Node.js versions installed via NVM.

Changes Made:
Updated the Node version validation to include v21 and v22.

Ensured backward compatibility for users running older but still supported Node versions.

This fix improves the accuracy of the setup validator and prevents unnecessary errors for users running the latest LTS or stable versions of Node.js.